### PR TITLE
Type fixes

### DIFF
--- a/MQTimeOut/MQTimeOut.h
+++ b/MQTimeOut/MQTimeOut.h
@@ -10,7 +10,7 @@ extern NSString *const MQTimerResetNotification;
 // Start timer with default 5 minutes
 - (void)startTimer;
 // Start timer with custom time
-- (void)startTimerWithSeconds:(NSInteger)seconds;
+- (void)startTimerWithSeconds:(NSTimeInterval)seconds;
 - (void)startTimerWithMinutes:(NSInteger)minutes;
 // Manually stop timer
 - (void)stopTimer;

--- a/MQTimeOut/MQTimeOut.h
+++ b/MQTimeOut/MQTimeOut.h
@@ -17,4 +17,5 @@ extern NSString *const MQTimerResetNotification;
 // Manually reset timer
 - (void)resetTimer;
 
++(instancetype) sharedApplication;
 @end

--- a/MQTimeOut/MQTimeOut.m
+++ b/MQTimeOut/MQTimeOut.m
@@ -14,6 +14,10 @@ NSString *const MQTimerResetNotification = @"MQTimerResetNotification";
 
 @implementation MQTimeOut
 
++(instancetype) sharedApplication {
+    return (MQTimeOut*)[super sharedApplication];
+}
+
 - (void)sendEvent:(UIEvent *)event {
 	[super sendEvent:event];
     
@@ -32,7 +36,6 @@ NSString *const MQTimerResetNotification = @"MQTimerResetNotification";
 - (void)resetTimer
 {
     if (self.timer) {
-        [self stopTimer];
         [self startCountDown];
         [[NSNotificationCenter defaultCenter]
          postNotificationName:MQTimerResetNotification object:nil];

--- a/MQTimeOut/MQTimeOut.m
+++ b/MQTimeOut/MQTimeOut.m
@@ -8,7 +8,7 @@ NSString *const MQTimerResetNotification = @"MQTimerResetNotification";
 @interface MQTimeOut()
 
 @property (nonatomic, strong) NSTimer *timer;
-@property (nonatomic) CGFloat timerSeconds;
+@property (nonatomic) NSTimeInterval timerSeconds;
 
 @end
 
@@ -63,14 +63,14 @@ NSString *const MQTimerResetNotification = @"MQTimerResetNotification";
     [self startCountDown];
 }
 
-- (void)startTimerWithSeconds:(NSInteger)seconds
+- (void)startTimerWithSeconds:(NSTimeInterval)seconds
 {
     self.timerSeconds = seconds;
     [self startCountDown];
 }
 - (void)startTimerWithMinutes:(NSInteger)minutes
 {
-    self.timerSeconds = minutes * 60;
+    self.timerSeconds = minutes * 60.f;
     [self startCountDown];
 }
 


### PR DESCRIPTION
Not sure why CGFloat was in there, and see no reason why seconds should
be an integer when the proper type is NSTimeInterval. Otherwise if you wanted to do more precise timing you would have to modify the file directly.